### PR TITLE
Added progress bar to import, laravel scout version...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,12 @@
     "require-dev": {
         "phpunit/phpunit": "^7.1",
         "mockery/mockery": "^1.0"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Ehann\\LaravelRediSearch\\RediSearchServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "laravel/scout": "^3.0|^4.0|^5.0",
+        "laravel/scout": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "ethanhann/redisearch-php": "^1.0.0",
         "ethanhann/redis-raw": "^0.3.1"
     },

--- a/src/Scout/Console/ImportCommand.php
+++ b/src/Scout/Console/ImportCommand.php
@@ -14,7 +14,7 @@ class ImportCommand extends Command
 {
     protected $signature = 'ehann:redisearch:import 
                             {model : The model class to import.} 
-                            {chunk-size : Import model chunk size. Default: 1000} 
+                            {--chunk-size=1000 : Import chunk size.} 
                             {--recreate-index : Drop the index before importing.}
                             {--no-id : Do not select by "id" primary key.}
                             {--no-import-models : Create index but dont import model.}
@@ -24,7 +24,7 @@ class ImportCommand extends Command
     public function handle(RedisRawClientInterface $redisClient)
     {
         $class = $this->argument('model');
-        $chunk_size = $this->argument('chunk-size') ?? 1000;
+        $chunk_size = $this->option('chunk-size') ?? 1000;
         $model = new $class();
         $index = new Index($redisClient, $model->searchableAs());
 

--- a/src/Scout/Console/ImportCommand.php
+++ b/src/Scout/Console/ImportCommand.php
@@ -79,7 +79,7 @@ class ImportCommand extends Command
             $records
                 ->chunk($chunk_size, function ($models) use ($index, $model, $bar) {
                     $documents = [];
-                    foreach($models as $model) {
+                    foreach($models as $item) {
                         $document = $index->makeDocument(
                             $item->getKey()
                         );

--- a/src/Scout/Console/ImportCommand.php
+++ b/src/Scout/Console/ImportCommand.php
@@ -70,7 +70,6 @@ class ImportCommand extends Command
         }
 
         if (!$this->option('no-import-models')) {
-
             $records_total = $class::count();
             if (!$records_total) {
                 $this->warn('There are no models to import.');

--- a/src/Scout/Console/ImportCommand.php
+++ b/src/Scout/Console/ImportCommand.php
@@ -94,7 +94,7 @@ class ImportCommand extends Command
                 });
             $bar->finish();
 
-            $this->info("[$class] models imported created successfully");
+            $this->info(PHP_EOL."[$class] models imported created successfully");
         } else {
             $this->info("$class index created successfully");
         }

--- a/src/Scout/Console/ImportCommand.php
+++ b/src/Scout/Console/ImportCommand.php
@@ -78,7 +78,6 @@ class ImportCommand extends Command
             $records = $class::select(DB::raw($query));
             $records
                 ->chunk($chunk_size, function ($models) use ($index, $model, $bar) {
-                    $documents = [];
                     foreach($models as $item) {
                         $document = $index->makeDocument(
                             $item->getKey()
@@ -89,11 +88,9 @@ class ImportCommand extends Command
                                 $document->$name->setValue($value);
                             }
                         }
-                        $documents[] = $document;
+                        $index->add($document);
                         $bar->advance();
                     }
-
-                    $index->addMany($documents);
                 });
             $bar->finish();
 

--- a/src/Scout/Engines/RediSearchEngine.php
+++ b/src/Scout/Engines/RediSearchEngine.php
@@ -189,7 +189,7 @@ class RediSearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results->first();
+        return $results->getCount();
     }
 
     public function flush($model)

--- a/src/Scout/Engines/RediSearchEngine.php
+++ b/src/Scout/Engines/RediSearchEngine.php
@@ -191,4 +191,10 @@ class RediSearchEngine extends Engine
     {
         return $results->first();
     }
+
+    public function flush($model)
+    {
+        $index = new Index($this->redisRawClient, (new $model())->searchableAs());
+        $index->drop();
+    }
 }


### PR DESCRIPTION
- Added newest versions of laravel/scout 6-7 to make it work with Laravel 6.
- Added [auto-discovery](https://laravel.com/docs/5.8/packages#package-discovery) for RediSearchServiceProvider
- Added [progress bar](http://dsro.ru/gyazo/images/74288e8c1289e821b568faec9680.png) to import command.
- Added chunk-size option to import command. We shouldn't load whole table to variable at once...
- Added engine method flush()
- Fixed getTotalCount()

Also tried to use `$index->addMany()` while import instead of `$index->add()` and make it "chunkable" too, but it [doesnt work](https://github.com/ethanhann/redisearch-php/issues/52)