### PR TITLE
Changed getCount to count.

### DIFF
--- a/src/Scout/Engines/RediSearchEngine.php
+++ b/src/Scout/Engines/RediSearchEngine.php
@@ -189,7 +189,7 @@ class RediSearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results->getCount();
+        return $results->count();
     }
 
     public function flush($model)


### PR DESCRIPTION
Hey  ireally enjoy this package and got me exactly what I was wanting. I apologize I am not extremely familiar with Laravel and its changes. Recently picked it up about a month ago. 

 I was trying to implement pagination, but was getting the error
```
 "Bad Method Call"
Method Illuminate\Support\Collection::getCount does not exist.
```

Followed the code and found `->count()` returned the results count. I do not know if maybe this was a Laravel change? Or if I'm just completely missing it and how i'm supposed to change it. But I googled for a bit and could not find a `getCounty()` for Laravel collections. For more context I'm running at Laravel 7.11.0. Would love to see this get merged so I do not have to side load this package and hopefully it helps others, without breaking it for anyone else. If I missed the mark of this and someone has a better suggestion I don't mind implementing it.( Maybe a check for older versions of Laravel that did use getCount?).

Thanks!
